### PR TITLE
Add Uneditable to Remaining Widgets

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -7056,6 +7056,11 @@ div.hide-file-list>div>div>div>div>form>div>div:nth-child(3) {
     background: rgba(214, 214, 214, 0.3);
 }
 
+.state-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .wizard-card-tools {
     float: right;
     padding-left: 10px;

--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -34,7 +34,8 @@ var WidgetViewModel = function(params) {
     this.form = params.form || null;
     this.tile = params.tile || null;
     this.widget = params.widget || null;
-    this.inResourceEditor = (typeof params.inResourceEditor === "boolean" ? params.inResourceEditor : null);
+    this.inResourceEditor = (typeof params.inResourceEditor === "boolean" ?
+        params.inResourceEditor : null);
     this.results = params.results || null;
     this.hideEmptyNodes = params.hideEmptyNodes;
     this.displayValue = ko.computed(function() {
@@ -53,6 +54,7 @@ var WidgetViewModel = function(params) {
     this.configKeys = params.configKeys || [];
     this.configKeys.push('label');
     this.configKeys.push('required');
+    this.configKeys.push('uneditable');
     this.valueProperties = params.valueProperties || [];
     if (this.node) {
         this.required = this.node.isrequired;
@@ -98,6 +100,24 @@ var WidgetViewModel = function(params) {
         var obs = ko.observable(self.config()[key]);
         subscribeConfigObservable(obs, key);
     });
+
+    if (ko.isObservable(self.uneditable)) {
+        var uneditableSub = self.uneditable.subscribe(function(val) {
+            if (ko.isWriteableObservable(self.disabled)) {
+                self.disabled(!!val);
+            }
+        });
+        self.disposables.push(uneditableSub);
+        if (ko.isWriteableObservable(self.disabled)) {
+            self.disabled(!!self.uneditable());
+        }
+    }
+
+    this.disable = ko.computed(function() {
+        return ko.unwrap(self.disabled) || (self.uneditable && ko.unwrap(self.uneditable)) || false;
+    });
+
+    this.disposables.push(this.disable);
 
     if (ko.isObservable(this.value) && ko.isObservable(this.defaultValue)) {
         var defaultValue = this.defaultValue();

--- a/arches/app/media/js/views/components/widgets/radio-boolean.js
+++ b/arches/app/media/js/views/components/widgets/radio-boolean.js
@@ -25,11 +25,11 @@ import 'bindings/key-events-click';
 
 const viewModel = function(params) {
     params.configKeys = ['trueLabel', 'falseLabel', 'defaultValue'];
-        
+
     WidgetViewModel.apply(this, [params]);
     var self = this;
     this.setValue = function(val) {
-        if (ko.unwrap(self.disabled) === false) {
+        if (ko.unwrap(self.disable) === false) {
             if (val === self.value()) {
                 self.value(null);
             } else {

--- a/arches/app/models/migrations/12350_widget_uneditable_config.py
+++ b/arches/app/models/migrations/12350_widget_uneditable_config.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+
+def add_uneditable_to_widgets(apps, schema_editor):
+    CardXNodeXWidget = apps.get_model("models", "CardXNodeXWidget")
+    Widget = apps.get_model("models", "Widget")
+
+    for widget in Widget.objects.all():
+        config = dict(widget.defaultconfig or {})
+        if "uneditable" not in config:
+            config["uneditable"] = False
+            widget.defaultconfig = config
+            widget.save()
+
+    for card_widget in CardXNodeXWidget.objects.all():
+        config = dict(card_widget.config or {})
+        if "uneditable" not in config:
+            config["uneditable"] = False
+            card_widget.config = config
+            card_widget.save()
+
+
+def remove_uneditable_from_widgets(apps, schema_editor):
+    CardXNodeXWidget = apps.get_model("models", "CardXNodeXWidget")
+    Widget = apps.get_model("models", "Widget")
+
+    for widget in Widget.objects.all():
+        config = dict(widget.defaultconfig or {})
+        config.pop("uneditable", None)
+        widget.defaultconfig = config
+        widget.save()
+
+    for card_widget in CardXNodeXWidget.objects.all():
+        config = dict(card_widget.config or {})
+        config.pop("uneditable", None)
+        card_widget.config = config
+        card_widget.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("models", "12343_generate_geom_feature_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_uneditable_to_widgets, remove_uneditable_from_widgets),
+    ]

--- a/arches/app/models/migrations/12600_widget_uneditable_config.py
+++ b/arches/app/models/migrations/12600_widget_uneditable_config.py
@@ -24,13 +24,23 @@ def remove_uneditable_from_widgets(apps, schema_editor):
     CardXNodeXWidget = apps.get_model("models", "CardXNodeXWidget")
     Widget = apps.get_model("models", "Widget")
 
-    for widget in Widget.objects.all():
+    widgets_to_remove = Widget.objects.exclude(
+        name__in=[
+            "non-localized-text-widget",
+            "number-widget",
+            "rich-text-widget",
+            "text-widget",
+        ]
+    ).all()
+    for widget in widgets_to_remove:
         config = dict(widget.defaultconfig or {})
         config.pop("uneditable", None)
         widget.defaultconfig = config
         widget.save()
 
-    for card_widget in CardXNodeXWidget.objects.all():
+    for card_widget in CardXNodeXWidget.objects.filter(
+        widget__in=widgets_to_remove
+    ).all():
         config = dict(card_widget.config or {})
         config.pop("uneditable", None)
         card_widget.config = config

--- a/arches/app/templates/views/components/iiif-widget-annotation.htm
+++ b/arches/app/templates/views/components/iiif-widget-annotation.htm
@@ -27,156 +27,158 @@
                 <div class="row widget-wrapper">
                     <div class="form-group">
                         <div class="col-xs-12">
-                            <div class="style-tools-collapser" data-bind=" click: function() {
-                                self.showStylingTools(!self.showStylingTools());
-                            }">
-                                <span data-bind="text: self.showStylingTools() ? $root.translations.hideStyleTools : $root.translations.showStyleTools"></span>
-                                <i class="fa" data-bind="{
-                                    css: {
-                                        'fa-caret-down' : !self.showStylingTools(),
-                                        'fa-caret-up' : self.showStylingTools(),
-                                    }
-                                }"></i>
-                            </div>
-                            <div class="form-horizontal" data-bind="if: self.showStylingTools">
-                                <div class="style-tools-panel">
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.lineColor"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <div class="colorpicker-component input-group">
-                                                <input 
-                                                    class="form-control input-lg widget-input" 
-                                                    data-bind="
-                                                        attr: {placeholder: $root.translations.lineColor},
-                                                        colorPicker: {color: self.lineColor, format:'hex'}
-                                                    "
-                                                >
-                                                <span class="input-group-addon style-tools-color-visualizer" data-bind="style: {background: self.lineColor}"></span>
+                            <div data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                                <div class="style-tools-collapser" data-bind=" click: function() {
+                                    self.showStylingTools(!self.showStylingTools());
+                                }">
+                                    <span data-bind="text: self.showStylingTools() ? $root.translations.hideStyleTools : $root.translations.showStyleTools"></span>
+                                    <i class="fa" data-bind="{
+                                        css: {
+                                            'fa-caret-down' : !self.showStylingTools(),
+                                            'fa-caret-up' : self.showStylingTools(),
+                                        }
+                                    }"></i>
+                                </div>
+                                <div class="form-horizontal" data-bind="if: self.showStylingTools">
+                                    <div class="style-tools-panel">
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.lineColor"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <div class="colorpicker-component input-group">
+                                                    <input
+                                                        class="form-control input-lg widget-input"
+                                                        data-bind="
+                                                            attr: {placeholder: $root.translations.lineColor},
+                                                            colorPicker: {color: self.lineColor, format:'hex'}
+                                                        "
+                                                    >
+                                                    <span class="input-group-addon style-tools-color-visualizer" data-bind="style: {background: self.lineColor}"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.fillColor"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <div class="colorpicker-component input-group">
+                                                    <input
+                                                        class="form-control input-lg widget-input"
+                                                        data-bind="
+                                                            attr: {placeholder: $root.translations.fillColor},
+                                                            colorPicker: {color: self.fillColor, format:'hex'}
+                                                        "
+                                                    >
+                                                    <span class="input-group-addon style-tools-color-visualizer" data-bind="style: {background: self.fillColor}"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.lineWidth"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.lineWidth">
+                                            </div>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.lineOpacity"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.lineOpacity">
+                                            </div>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.pointRadius"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.pointRadius">
+                                            </div>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="col-sm-4 control-label">
+                                                <span data-bind="text: $root.translations.fillOpacity"></span>
+                                            </label>
+                                            <div class="col-sm-8">
+                                                <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.fillOpacity">
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.fillColor"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <div class="colorpicker-component input-group">
-                                                <input 
-                                                    class="form-control input-lg widget-input" 
-                                                    data-bind="
-                                                        attr: {placeholder: $root.translations.fillColor},
-                                                        colorPicker: {color: self.fillColor, format:'hex'}
-                                                    "
-                                                >
-                                                <span class="input-group-addon style-tools-color-visualizer" data-bind="style: {background: self.fillColor}"></span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.lineWidth"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.lineWidth">
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.lineOpacity"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.lineOpacity">
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.pointRadius"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.pointRadius">
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="col-sm-4 control-label">
-                                            <span data-bind="text: $root.translations.fillOpacity"></span>
-                                        </label>
-                                        <div class="col-sm-8">
-                                            <input type="number" placeholder="" class="form-control" data-bind="valueUpdate: 'keyup', value: self.fillOpacity">
-                                        </div>
-                                    </div>
                                 </div>
-                            </div>
-                            <div class="map-card-feature-list">
-                                <div class="add-new-feature" data-bind="visible: !self.disableDrawing()">
-                                    <select 
-                                        data-bind="
-                                            placeholder: $root.translations.addANewFeature + '...',
-                                            value: self.featureLookup[widget.node_id()].selectedTool,
-                                            valueAllowUnset: true,
-                                            options: [
-                                                {
-                                                    value: '',
-                                                    text: ''
-                                                },
-                                                {
-                                                    value: 'draw_point',
-                                                    text: $root.translations.mapAddPoint
-                                                },
-                                                {
-                                                    value: 'draw_line_string',
-                                                    text: $root.translations.mapAddLine
-                                                },
-                                                {
-                                                    value: 'draw_polygon',
-                                                    text: $root.translations.mapAddPolygon
+                                <div class="map-card-feature-list">
+                                    <div class="add-new-feature" data-bind="visible: !self.disableDrawing()">
+                                        <select
+                                            data-bind="
+                                                placeholder: $root.translations.addANewFeature + '...',
+                                                value: self.featureLookup[widget.node_id()].selectedTool,
+                                                valueAllowUnset: true,
+                                                options: [
+                                                    {
+                                                        value: '',
+                                                        text: ''
+                                                    },
+                                                    {
+                                                        value: 'draw_point',
+                                                        text: $root.translations.mapAddPoint
+                                                    },
+                                                    {
+                                                        value: 'draw_line_string',
+                                                        text: $root.translations.mapAddLine
+                                                    },
+                                                    {
+                                                        value: 'draw_polygon',
+                                                        text: $root.translations.mapAddPolygon
+                                                    }
+                                                ],
+                                                optionsText: 'text',
+                                                optionsValue: 'value',
+                                                chosen: {
+                                                    'width': '100%',
+                                                    'disable_search_threshold': 10,
+                                                    'allow_single_deselect': true
                                                 }
-                                            ],
-                                            optionsText: 'text',
-                                            optionsValue: 'value',
-                                            chosen: {
-                                                'width': '100%',
-                                                'disable_search_threshold': 10,
-                                                'allow_single_deselect': true
-                                            }
-                                        "   
-                                    ></select>
-                                </div>
-                                <div class="add-new-feature" data-bind="visible: self.disableDrawing">
-                                    <select 
-                                        data-bind="
-                                            placeholder: $root.translations.addANewFeature + '...',
-                                            value: self.featureLookup[widget.node_id()].selectedTool,
-                                            valueAllowUnset: true,
-                                            options: [
-                                                {
-                                                    value: '',
-                                                    text: ''
-                                                },
-                                                {
-                                                    value: 'draw_point',
-                                                    text: $root.translations.mapAddPoint
-                                                },
-                                                {
-                                                    value: 'draw_line_string',
-                                                    text: $root.translations.mapAddLine
-                                                },
-                                                {
-                                                    value: 'draw_polygon',
-                                                    text: $root.translations.mapAddPolygon
+                                            "
+                                        ></select>
+                                    </div>
+                                    <div class="add-new-feature" data-bind="visible: self.disableDrawing">
+                                        <select
+                                            data-bind="
+                                                placeholder: $root.translations.addANewFeature + '...',
+                                                value: self.featureLookup[widget.node_id()].selectedTool,
+                                                valueAllowUnset: true,
+                                                options: [
+                                                    {
+                                                        value: '',
+                                                        text: ''
+                                                    },
+                                                    {
+                                                        value: 'draw_point',
+                                                        text: $root.translations.mapAddPoint
+                                                    },
+                                                    {
+                                                        value: 'draw_line_string',
+                                                        text: $root.translations.mapAddLine
+                                                    },
+                                                    {
+                                                        value: 'draw_polygon',
+                                                        text: $root.translations.mapAddPolygon
+                                                    }
+                                                ],
+                                                optionsText: 'text',
+                                                optionsValue: 'value',
+                                                chosen: {
+                                                    'disabled': true,
+                                                    'width': '100%',
+                                                    'disable_search_threshold': 10,
+                                                    'allow_single_deselect': true
                                                 }
-                                            ],
-                                            optionsText: 'text',
-                                            optionsValue: 'value',
-                                            chosen: {
-                                                'disabled': true,
-                                                'width': '100%',
-                                                'disable_search_threshold': 10,
-                                                'allow_single_deselect': true
-                                            }
-                                        "
-                                    ></select>
+                                            "
+                                        ></select>
+                                    </div>
                                 </div>
                             </div>
                             <table class="table">
@@ -186,13 +188,13 @@
                                         <td>
                                             <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
                                         </td>
-                                        <td class="map-card-feature-tool">
+                                        <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
                                             <a href="javascript:void(0);" data-bind="click: function() { self.editFeature(feature); }, clickBubble: false">
                                                 <i class="fa fa-pencil map-card-feature-edit"></i>
                                                 <span data-bind="text: $root.translations.edit"></span>
                                             </a>
                                         </td>
-                                        <td class="map-card-feature-tool">
+                                        <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
                                             <a href="javascript:void(0);" data-bind="click: function() { self.deleteFeature(feature); }, clickBubble: false">
                                                 <i class="fa fa-trash map-card-feature-delete"></i>
                                                 <span data-bind="text: $root.translations.delete"></span>

--- a/arches/app/templates/views/components/iiif-widget-annotation.htm
+++ b/arches/app/templates/views/components/iiif-widget-annotation.htm
@@ -27,7 +27,7 @@
                 <div class="row widget-wrapper">
                     <div class="form-group">
                         <div class="col-xs-12">
-                            <div data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                            <div data-bind="css: {'state-disabled': self.disable()}">
                                 <div class="style-tools-collapser" data-bind=" click: function() {
                                     self.showStylingTools(!self.showStylingTools());
                                 }">
@@ -188,13 +188,13 @@
                                         <td>
                                             <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
                                         </td>
-                                        <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                                        <td class="map-card-feature-tool" data-bind="css: {'state-disabled': self.disable()}">
                                             <a href="javascript:void(0);" data-bind="click: function() { self.editFeature(feature); }, clickBubble: false">
                                                 <i class="fa fa-pencil map-card-feature-edit"></i>
                                                 <span data-bind="text: $root.translations.edit"></span>
                                             </a>
                                         </td>
-                                        <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                                        <td class="map-card-feature-tool" data-bind="css: {'state-disabled': self.disable()}">
                                             <a href="javascript:void(0);" data-bind="click: function() { self.deleteFeature(feature); }, clickBubble: false">
                                                 <i class="fa fa-trash map-card-feature-delete"></i>
                                                 <span data-bind="text: $root.translations.delete"></span>

--- a/arches/app/templates/views/components/map-widget-editor.htm
+++ b/arches/app/templates/views/components/map-widget-editor.htm
@@ -32,7 +32,7 @@
     </div>
     <div class="workbench-card-sidepanel-border"></div>
         <div class="new-provisional-edit-card-container" style="height: 100%">
-            <!-- ko if: geoJSONString() !== undefined -->
+            <!-- ko if: !disable() && geoJSONString() !== undefined -->
             <div class="card">
                 <div class="geojson-editor" data-bind="codemirror: {
                     value: geoJSONString,
@@ -64,68 +64,73 @@
             </div>
             <!-- /ko-->
 
+            <!-- ko ifnot: disable -->
             {% include 'views/components/coordinate-editor.htm' %}
 
             {% include 'views/components/buffer-editor.htm' %}
+            <!-- /ko -->
 
             <div class="card" data-bind="visible: geoJSONString() === undefined && !coordinateEditing() && !bufferNodeId()">
                 <div class="row widget-wrapper">
                     <div class="form-group">
                         <div class="col-xs-12">
                             <div class="map-card-feature-list">
-                                <div class="add-new-feature">
-                                    <select
-                                        data-bind="
-                                            placeholder: $root.translations.addANewFeature + '...',
-                                            value: self.featureLookup[widget.node_id()].selectedTool,
-                                            valueAllowUnset: true,
-                                            options: widget.drawTools,
-                                            optionsText: 'text',
-                                            optionsValue: 'value',
-                                            chosen: {
-                                                'width': '100%',
-                                                'disable_search_threshold': 10,
-                                                'allow_single_deselect': true
-                                            },
-                                            attr: {'aria-label': $root.translations.addANewFeature}
-                                        "
-                                    ></select>
-                                </div>
-                                <div>
-                                    <div class="map-data-drop-area" tabindex="0" role="button"
-                                        data-bind="event: {
-                                            dragover: dropZoneOverHandler,
-                                            drop: dropZoneHandler,
-                                            click: dropZoneClickHandler,
-                                            dragenter: dropZoneEnterHandler,
-                                            dragleave: dropZoneLeaveHandler,
-                                            dragend: dropZoneLeaveHandler
-                                        }, attr: {'aria-label': $root.translations.dragGeoJsonKml},
-                                        onEnterkeyClick, onSpaceClick
-                                        ">
-                                        <span data-bind="text: $root.translations.dragGeoJsonKml"></span>
+                                <div data-bind="style: {opacity: disable() ? 0.5 : 1, 'pointer-events': disable() ? 'none' : 'auto'}">
+                                    <div class="add-new-feature">
+                                        <select
+                                            data-bind="
+                                                placeholder: $root.translations.addANewFeature + '...',
+                                                value: self.featureLookup[widget.node_id()].selectedTool,
+                                                valueAllowUnset: true,
+                                                options: widget.drawTools,
+                                                optionsText: 'text',
+                                                optionsValue: 'value',
+                                                disable: disable,
+                                                chosen: {
+                                                    'width': '100%',
+                                                    'disable_search_threshold': 10,
+                                                    'allow_single_deselect': true
+                                                },
+                                                attr: {'aria-label': $root.translations.addANewFeature}
+                                            "
+                                        ></select>
                                     </div>
-                                    <div class="hidden-file-input">
-                                        <input type="file" accept=".json,.geojson,.kml,.shp,.zip" data-bind="event: {
-                                            change: self.dropZoneFileSelected
-                                        }"/>
+                                    <div>
+                                        <div class="map-data-drop-area" tabindex="0" role="button"
+                                            data-bind="event: {
+                                                dragover: dropZoneOverHandler,
+                                                drop: dropZoneHandler,
+                                                click: dropZoneClickHandler,
+                                                dragenter: dropZoneEnterHandler,
+                                                dragleave: dropZoneLeaveHandler,
+                                                dragend: dropZoneLeaveHandler
+                                            }, attr: {'aria-label': $root.translations.dragGeoJsonKml},
+                                            onEnterkeyClick, onSpaceClick
+                                            ">
+                                            <span data-bind="text: $root.translations.dragGeoJsonKml"></span>
+                                        </div>
+                                        <div class="hidden-file-input">
+                                            <input type="file" accept=".json,.geojson,.kml,.shp,.zip" data-bind="event: {
+                                                change: self.dropZoneFileSelected
+                                            }"/>
+                                        </div>
                                     </div>
+                                    <!-- ko if: self.featureLookup[widget.node_id()].dropErrors().length !== 0 -->
+                                    <div class="geojson-error-list">
+                                        <a href="javascript: void(0);" data-bind="click:function () {
+                                            self.featureLookup[widget.node_id()].dropErrors([]);
+                                        }">
+                                            <i class="fa fa-close"></i>
+                                        </a>
+                                        <span data-bind="text: $root.translations.followingErrorsOccurred"></span>
+                                        <ul>
+                                            <!-- ko foreach: self.featureLookup[widget.node_id()].dropErrors() -->
+                                            <li data-bind="text: message"></li>
+                                            <!-- /ko-->
+                                        </ul>
+                                    </div>
+                                    <!-- /ko-->
                                 </div>
-                                <!-- ko if: self.featureLookup[widget.node_id()].dropErrors().length !== 0 -->
-                                <div class="geojson-error-list">
-                                    <a href="javascript: void(0);" data-bind="click:function () {
-                                        self.featureLookup[widget.node_id()].dropErrors([]);
-                                    }">
-                                        <i class="fa fa-close"></i>
-                                    </a>
-                                    <span data-bind="text: $root.translations.followingErrorsOccurred"></span>
-                                    <ul>
-                                        <!-- ko foreach: self.featureLookup[widget.node_id()].dropErrors() -->
-                                        <li data-bind="text: message"></li>
-                                        <!-- /ko-->
-                                    </ul>
-                                </div>
-                                <!-- /ko-->
                                 <table class="table">
                                     <tbody>
                                         <!-- ko foreach: {data: self.featureLookup[widget.node_id()].features, as: 'feature'} -->
@@ -133,7 +138,7 @@
                                             <td>
                                                 <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
                                             </td>
-                                            <td class="map-card-feature-tool">
+                                            <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
                                                 <a href="javascript:void(0);" role="button" data-bind="click: function() { self.editFeature(feature) }, clickBubble: false,
                                                     attr: {'aria-label': $root.translations.editFeature}
                                                 ">
@@ -141,7 +146,7 @@
                                                     <span data-bind="text: $root.translations.edit"></span>
                                                 </a>
                                             </td>
-                                            <td class="map-card-feature-tool">
+                                            <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
                                                 <a href="javascript:void(0);" role="button" data-bind="click: function() { self.deleteFeature(feature) }, clickBubble: false,
                                                     attr: {'aria-label': $root.translations.deleteFeature}
                                                 ">
@@ -153,7 +158,7 @@
                                         <!-- /ko -->
                                     </tbody>
                                 </table>
-                                <div class="map-card-zoom-tool">
+                                <div class="map-card-zoom-tool" data-bind="style: {opacity: disable() ? 0.5 : 1, 'pointer-events': disable() ? 'none' : 'auto'}">
                                     <button data-bind="click: function() {
                                         self.editGeoJSON(self.featureLookup[widget.node_id()].features(), widget.node_id());
                                     }">

--- a/arches/app/templates/views/components/map-widget-editor.htm
+++ b/arches/app/templates/views/components/map-widget-editor.htm
@@ -75,7 +75,7 @@
                     <div class="form-group">
                         <div class="col-xs-12">
                             <div class="map-card-feature-list">
-                                <div data-bind="style: {opacity: disable() ? 0.5 : 1, 'pointer-events': disable() ? 'none' : 'auto'}">
+                                <div data-bind="css: {'state-disabled': disable()}">
                                     <div class="add-new-feature">
                                         <select
                                             data-bind="
@@ -138,7 +138,7 @@
                                             <td>
                                                 <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
                                             </td>
-                                            <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                                            <td class="map-card-feature-tool" data-bind="css: {'state-disabled': self.disable()}">
                                                 <a href="javascript:void(0);" role="button" data-bind="click: function() { self.editFeature(feature) }, clickBubble: false,
                                                     attr: {'aria-label': $root.translations.editFeature}
                                                 ">
@@ -146,7 +146,7 @@
                                                     <span data-bind="text: $root.translations.edit"></span>
                                                 </a>
                                             </td>
-                                            <td class="map-card-feature-tool" data-bind="style: {opacity: self.disable() ? 0.5 : 1, 'pointer-events': self.disable() ? 'none' : 'auto'}">
+                                            <td class="map-card-feature-tool" data-bind="css: {'state-disabled': self.disable()}">
                                                 <a href="javascript:void(0);" role="button" data-bind="click: function() { self.deleteFeature(feature) }, clickBubble: false,
                                                     attr: {'aria-label': $root.translations.deleteFeature}
                                                 ">
@@ -158,7 +158,7 @@
                                         <!-- /ko -->
                                     </tbody>
                                 </table>
-                                <div class="map-card-zoom-tool" data-bind="style: {opacity: disable() ? 0.5 : 1, 'pointer-events': disable() ? 'none' : 'auto'}">
+                                <div class="map-card-zoom-tool" data-bind="css: {'state-disabled': disable()}">
                                     <button data-bind="click: function() {
                                         self.editGeoJSON(self.featureLookup[widget.node_id()].features(), widget.node_id());
                                     }">

--- a/arches/app/templates/views/components/widgets/base.htm
+++ b/arches/app/templates/views/components/widgets/base.htm
@@ -24,5 +24,24 @@
 
 <!-- ko if: configForm -->
 {% block config_form %}
+<div class="node-config-item">
+    <div class="control-label">
+        <span>Disable Editing</span>
+    </div>
+    <div class="pad-no">
+        <div data-bind="
+            component: {
+                name: 'views/components/simple-switch',
+                params: {
+                    value: uneditable,
+                    config:{
+                        label: 'Uneditable',
+                        subtitle: 'Prevent users from editing this value'
+                    }
+                }
+            }">
+        </div>
+    </div>
+</div>
 {% endblock config_form %}
 <!-- /ko -->

--- a/arches/app/templates/views/components/widgets/checkbox.htm
+++ b/arches/app/templates/views/components/widgets/checkbox.htm
@@ -22,7 +22,7 @@
                         'aria-checked': $parent.isOptionSelected($data)
                     }"
                     tabindex="0" role="checkbox">
-                    <input type="checkbox" data-bind="checked: $parent.isOptionSelected($data), disable: disable">
+                    <input type="checkbox" data-bind="checked: $parent.isOptionSelected($data), disable: $parent.disable">
                     <span data-bind="text:text"></span>
                 </label>
             </div>

--- a/arches/app/templates/views/components/widgets/checkbox.htm
+++ b/arches/app/templates/views/components/widgets/checkbox.htm
@@ -22,7 +22,7 @@
                         'aria-checked': $parent.isOptionSelected($data)
                     }"
                     tabindex="0" role="checkbox">
-                    <input type="checkbox" data-bind="checked: $parent.isOptionSelected($data)">
+                    <input type="checkbox" data-bind="checked: $parent.isOptionSelected($data), disable: disable">
                     <span data-bind="text:text"></span>
                 </label>
             </div>

--- a/arches/app/templates/views/components/widgets/checkbox.htm
+++ b/arches/app/templates/views/components/widgets/checkbox.htm
@@ -57,4 +57,5 @@
         </div>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/checkbox.htm
+++ b/arches/app/templates/views/components/widgets/checkbox.htm
@@ -13,7 +13,7 @@
                 <label class="form-checkbox form-normal form-primary form-text"
                     data-bind="css: {
                         'active': $parent.isOptionSelected($data),
-                        'disabled': $parent.disabled
+                        'disabled': $parent.disable
                     },
                     onEnterkeyClick,
                     onSpaceClick,

--- a/arches/app/templates/views/components/widgets/concept-select.htm
+++ b/arches/app/templates/views/components/widgets/concept-select.htm
@@ -11,7 +11,7 @@
         <div class="col-xs-12 resource-instance-wrapper" data-bind="class: nodeCssClasses">
             <select style="display:inline-block;"
                 data-bind="
-                    disable: disabled,
+                    disable: disable,
                     select2Query: {
                         select2Config: select2Config
                     },

--- a/arches/app/templates/views/components/widgets/concept-select.htm
+++ b/arches/app/templates/views/components/widgets/concept-select.htm
@@ -54,6 +54,7 @@
         </div>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/datepicker.htm
+++ b/arches/app/templates/views/components/widgets/datepicker.htm
@@ -12,7 +12,7 @@
         <div class="col-xs-12">
             <div>
                 <div class="input-group date">
-                    <input type="text" data-bind="value: value, placeholder: placeholder, disable: disabled, attr: {'aria-label': label},
+                    <input type="text" data-bind="value: value, placeholder: placeholder, disable: disable, attr: {'aria-label': label},
                         datepicker: {format: dateFormat, viewMode: viewMode, maxDate: maxDate, minDate: minDate}" class="form-control input-lg"
                         ><span class="input-group-addon date-icon"><i class="fa fa-calendar fa-lg date-icon"></i></span>
                 </div>

--- a/arches/app/templates/views/components/widgets/datepicker.htm
+++ b/arches/app/templates/views/components/widgets/datepicker.htm
@@ -102,4 +102,5 @@
         <span class="arches-toggle-subtitle" id="default-date-switcher-context" data-bind="text: $root.translations.useDateOfDataEntryForDefaultValue"></span>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/edtf.htm
+++ b/arches/app/templates/views/components/widgets/edtf.htm
@@ -156,4 +156,5 @@
         "
     >
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/edtf.htm
+++ b/arches/app/templates/views/components/widgets/edtf.htm
@@ -117,7 +117,7 @@
             <input type="text" data-bind="
                 textInput: value,
                 disable: disable,
-                attr: {placeholder: placeholder, disabled: disabled, 'aria-label': label}"
+                attr: {placeholder: placeholder, disabled: disable, 'aria-label': label}"
                 class="form-control input-lg widget-input">
         </div>
         <div class="col-xs-12" data-bind="if: value">

--- a/arches/app/templates/views/components/widgets/edtf.htm
+++ b/arches/app/templates/views/components/widgets/edtf.htm
@@ -116,6 +116,7 @@
         <div class="col-xs-12">
             <input type="text" data-bind="
                 textInput: value,
+                disable: disable,
                 attr: {placeholder: placeholder, disabled: disabled, 'aria-label': label}"
                 class="form-control input-lg widget-input">
         </div>

--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -20,7 +20,7 @@
                             <span data-bind="text: $root.translations.dragAndDropFilesOnPanel"></span>
                         </div>
                     </div>
-                    <button type="button" class="btn btn-lg btn-file-select fileinput-button dz-clickable" data-bind="css: uniqueidClass, disable: disabled">
+                    <button type="button" class="btn btn-lg btn-file-select fileinput-button dz-clickable" data-bind="css: uniqueidClass, disable: disable">
                         <i class="fa fa-file"></i>
                         <span data-bind="text: $root.translations.selectFiles"></span>
                     </button>

--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -219,7 +219,7 @@
         "
     >
 </div>
-
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/iiif.htm
+++ b/arches/app/templates/views/components/widgets/iiif.htm
@@ -31,6 +31,7 @@
         "
     >
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/map.htm
+++ b/arches/app/templates/views/components/widgets/map.htm
@@ -63,9 +63,9 @@
     <span data-bind="text: $root.translations.mapCenterLongitude"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-    <input 
-        type="number" 
-        class="form-control input-md widget-input" 
+    <input
+        type="number"
+        class="form-control input-md widget-input"
         data-bind="
             attr: {placeholder: $root.translations.longitudeXCoordinate, 'aria-label': $root.translations.longitudeXCoordinate},
             textInput: centerX
@@ -76,9 +76,9 @@
     <span data-bind="text: $root.translations.mapCenterLatitude"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-    <input 
-        type="number" 
-        class="form-control input-md widget-input" 
+    <input
+        type="number"
+        class="form-control input-md widget-input"
         data-bind="
             attr: {placeholder: $root.translations.latitudeYCoordinate, 'aria-label': $root.translations.latitudeYCoordinate},
             textInput: centerY
@@ -89,17 +89,18 @@
     <span data-bind="text: $root.translations.defaultZoom"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-    <input 
-        type="number" 
-        min=1 
-        max=20 
-        class="form-control input-md widget-input" 
+    <input
+        type="number"
+        min=1
+        max=20
+        class="form-control input-md widget-input"
         data-bind="
             attr: {placeholder: $root.translations.zoomLevel, 'aria-label': $root.translations.zoomLevel},
             textInput: zoom
         "
     >
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block display_value %}

--- a/arches/app/templates/views/components/widgets/node-value-select.htm
+++ b/arches/app/templates/views/components/widgets/node-value-select.htm
@@ -12,7 +12,7 @@
         <!-- /ko -->
         <div class="col-xs-12 resource-instance-wrapper">
             <select style="width:30%; display:inline-block;"
-                data-bind="disable: disabled, select2Query: {
+                data-bind="disable: disable, select2Query: {
                     select2Config: select2Config
                 }
             "></select>

--- a/arches/app/templates/views/components/widgets/node-value-select.htm
+++ b/arches/app/templates/views/components/widgets/node-value-select.htm
@@ -12,7 +12,7 @@
         <!-- /ko -->
         <div class="col-xs-12 resource-instance-wrapper">
             <select style="width:30%; display:inline-block;"
-                data-bind=" select2Query: {
+                data-bind="disable: disabled, select2Query: {
                     select2Config: select2Config
                 }
             "></select>
@@ -21,7 +21,6 @@
     </div>
 </div>
 {% endblock form %}
-
 
 {% block config_form %}
 <div>
@@ -53,6 +52,7 @@
         </div>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/non-localized-text.htm
+++ b/arches/app/templates/views/components/widgets/non-localized-text.htm
@@ -8,7 +8,7 @@
         <!-- ko if: node -->
         <i data-bind="
             css: {'ion-asterisk widget-label-required': node.isrequired},
-            attr: {'aria-label': $root.translations.required}        
+            attr: {'aria-label': $root.translations.required}
         "></i>
         <!-- /ko -->
         <div class="col-xs-12">
@@ -23,7 +23,7 @@
     <span data-bind="text: $root.translations.placeholder"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-    <input class="form-control input-md widget-input" 
+    <input class="form-control input-md widget-input"
         data-bind="attr: {placeholder: $root.translations.placeholder, 'aria-label': $root.translations.placeholder}, textInput: placeholder"
     >
 </div>
@@ -43,30 +43,12 @@
     <span data-bind="text: $root.translations.defaultValue"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-    <input type="" placeholder="{% trans "Default Value" %}" class="form-control input-md widget-input" 
+    <input type="" placeholder="{% trans "Default Value" %}" class="form-control input-md widget-input"
         data-bind="
-            textInput: defaultValue, 
+            textInput: defaultValue,
             attr:{'placeholder': $root.translations.defaultValue, 'aria-label': $root.translations.placeholder}
         "
     >
 </div>
-<div class="node-config-item">
-    <div class="control-label">
-        <span data-bind="text: $root.translations.disabled"></span>
-    </div>
-    <div class="pad-no">
-        <div data-bind="
-            component: { 
-                name: 'views/components/simple-switch', 
-                params: {
-                    value: uneditable, 
-                    config:{
-                        label: $root.translations.disableEditing,
-                        subtitle: $root.translations.preventUsersFromEditingValue
-                    }
-                }
-            }">
-        </div>
-    </div>
-</div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/number.htm
+++ b/arches/app/templates/views/components/widgets/number.htm
@@ -190,25 +190,5 @@
     "
 >
 </div>
-<div class="node-config-item">
-    <div class="control-label">
-        <span data-bind="text: $root.translations.disabled"></span>
-    </div>
-    <div class="pad-no">
-        <div
-            data-bind="
-                component: {
-                    name: 'views/components/simple-switch',
-                    params: {
-                        value: uneditable,
-                        config:{
-                            label: $root.translations.disableEditing,
-                            subtitle: $root.translations.preventUsersFromEditingValue
-                        }
-                    }
-                }
-            "
-        ></div>
-    </div>
-</div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/radio-boolean.htm
+++ b/arches/app/templates/views/components/widgets/radio-boolean.htm
@@ -11,13 +11,13 @@
       </div></div>
       <div class="col-xs-12">
         <div class="pad-hor" role="radiogroup" data-bind="attr:{'aria-label': label}">
-            <label data-bind="css: { 'active': value() === true, 'disabled': disabled }, onEnterkeyClick, onSpacekeyClick, click: function(e){setValue(true)}, attr: {'aria-checked': value() === true}"
+            <label data-bind="css: { 'active': value() === true, 'disabled': disable }, onEnterkeyClick, onSpacekeyClick, click: function(e){setValue(true)}, attr: {'aria-checked': value() === true}"
                 class="form-radio form-normal form-text" tabindex="0" role="radio">
-                <input type="radio" name="stat-w-label" data-bind="checked: value() === true"><span data-bind="text:node.config.trueLabel"></span>
+                <input type="radio" name="stat-w-label" data-bind="checked: value() === true, disable: disable"><span data-bind="text:node.config.trueLabel"></span>
             </label>
-            <label data-bind="css: { 'active': value() === false, 'disabled': disabled }, onEnterkeyClick, onSpacekeyClick, click: function(e){setValue(false)}, attr: {'aria-checked': value() === false}"
+            <label data-bind="css: { 'active': value() === false, 'disabled': disable }, onEnterkeyClick, onSpacekeyClick, click: function(e){setValue(false)}, attr: {'aria-checked': value() === false}"
                 class="form-radio form-normal form-text" tabindex="0" role="radio">
-                <input type="radio" name="stat-w-label" data-bind="checked: value() === false"><span data-bind="text:node.config.falseLabel"></span>
+                <input type="radio" name="stat-w-label" data-bind="checked: value() === false, disable: disable"><span data-bind="text:node.config.falseLabel"></span>
             </label>
         </div>
       </div>

--- a/arches/app/templates/views/components/widgets/radio-boolean.htm
+++ b/arches/app/templates/views/components/widgets/radio-boolean.htm
@@ -41,4 +41,5 @@
         </label>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/radio.htm
+++ b/arches/app/templates/views/components/widgets/radio.htm
@@ -67,5 +67,5 @@
         </div>
     </div>
 </div>
-
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/radio.htm
+++ b/arches/app/templates/views/components/widgets/radio.htm
@@ -13,7 +13,7 @@
                 <label class="form-radio form-normal form-text" role="radio"
                     data-bind="css: {
                         'active': $parent.isOptionSelected($data),
-                        'disabled': $parent.disabled
+                        'disabled': $parent.disable
                     },
                     onEnterkeyClick,
                     onSpaceClick,

--- a/arches/app/templates/views/components/widgets/resource-instance-select.htm
+++ b/arches/app/templates/views/components/widgets/resource-instance-select.htm
@@ -9,6 +9,7 @@
     <div class="col-xs-12 resource-instance-wrapper">
         <select style="width:30%; display:inline-block;"
             data-bind="
+                disable: disable,
                 select2Query: {
                     select2Config: select2Config
                 },
@@ -29,6 +30,7 @@
             <div class="col-xs-12 resource-instance-wrapper">
                 <select style="width:30%; display:inline-block;"
                     data-bind="
+                        disable: disable,
                         select2Query: {
                             select2Config: select2Config
                         },
@@ -48,7 +50,7 @@
                     class="form-control"
                     style="width: 225px; height:28px;"
                     data-bind="
-                        attr: {placeholder: $root.translations.filter + '...', 'aria-label': $root.translations.filter}, 
+                        attr: {placeholder: $root.translations.filter + '...', 'aria-label': $root.translations.filter},
                         textInput: filter
                     "
                 ></input>
@@ -70,8 +72,9 @@
                             </button>
                         </div>
                         <div class='rr-table-column icon-column'>
-                            <button data-bind="click: $parent.deleteRelationship, clickBubble: false,
-                                    attr: {'aria-label': $root.translations.deleteRelationshipResource($data.resourceName())}
+                            <button data-bind="click: function() { if (!$parent.disable()) { $parent.deleteRelationship($data); } }, clickBubble: false,
+                                    attr: {'aria-label': $root.translations.deleteRelationshipResource($data.resourceName())},
+                                    disable: $parent.disable
                             ">
                                 <i class="fa fa-trash" aria-hidden="true"></i>
                             </button>
@@ -106,7 +109,7 @@
                         <!-- /ko -->
                     </div>
                     <!-- Ontology Properties Accordion -->
-                    <div class="rr-table-row-panel" 
+                    <div class="rr-table-row-panel"
                         data-bind="visible: self.selectedResourceRelationship() === $data, if: self.selectedResourceRelationship() === $data, css: { 'rr-table-border': self.selectedResourceRelationship() === $data} ">
 
                         <div class="row" data-bind="let: {resourceToRRLabel: Math.random().toString(), rrToResourceLabel: Math.random().toString()}">
@@ -125,9 +128,10 @@
 
                                     <!-- Property -->
                                     <span class="col-xs-12">
-                                        <select 
-                                            style="max-width:100%; display:inline-block; margin: 3px 0px;" 
+                                        <select
+                                            style="max-width:100%; display:inline-block; margin: 3px 0px;"
                                             data-bind="
+                                                disable: self.disable,
                                                 select2Query: {
                                                     select2Config: self.getSelect2ConfigForOntologyProperties(
                                                         $data.ontologyProperty,
@@ -161,9 +165,10 @@
 
                                     <!-- Property -->
                                     <span class="col-xs-12">
-                                        <select 
-                                            style="width:100%; display:inline-block; margin: 3px 0px;" 
+                                        <select
+                                            style="width:100%; display:inline-block; margin: 3px 0px;"
                                             data-bind="
+                                                disable: self.disable,
                                                 select2Query: {
                                                     select2Config: self.getSelect2ConfigForOntologyProperties(
                                                         $data.inverseOntologyProperty,
@@ -228,7 +233,6 @@
     }"></div>
     <!-- /ko -->
 </div>
-
 {% endblock form %}
 
 {% block config_form %}
@@ -241,7 +245,7 @@
             class="form-control input-md widget-input"
             data-bind="
                 attr: {placeholder: $root.translations.placeholder, 'aria-label': $root.translations.placeholder},
-                value: placeholder, 
+                value: placeholder,
                 valueUpdate: 'keyup'
             "
         >
@@ -268,7 +272,7 @@
         <div class="form-group">
                         <div class="row" style="margin: 0px;">
                 <div class="col-xs-12 resource-instance-wrapper">
-                    <select style="width:30%; display:inline-block;" data-bind="                 
+                    <select style="width:30%; display:inline-block;" data-bind="
                             select2Query: {
                                 select2Config: select2Config
                             },
@@ -320,7 +324,7 @@
                             </div>
                             <div class='rr-table-column icon-column'>
                                 <button data-bind="onEnterkeyClick, onSpaceClick, click:function(){self.reportResourceId(ko.unwrap($data.resourceId));}, clickBubble: false,
-                                        attr: {'aria-label': $root.translations.expandResourceReport($data.resourceName())}    
+                                        attr: {'aria-label': $root.translations.expandResourceReport($data.resourceName())}
                                 ">
                                     <i class="fa fa-info-circle" aria-hidden="true"></i>
                                 </button>
@@ -347,7 +351,7 @@
                                         <span data-bind="text: $root.translations.resourcesRelationshipTo"></span>
                                         <span data-bind="text: $data.resourceName"></span>
                                     </div>
-    
+
                                     <div class="row" style="padding: 0px 12px; margin-bottom: 10px;">
                                         <!-- Instance name -->
                                         <span class="col-xs-12" style="text-align: left;"
@@ -356,7 +360,7 @@
 
                                         <!-- Property -->
                                         <span class="col-xs-12">
-                                            <select 
+                                            <select
                                                 style="max-width:100%; display:inline-block; margin: 3px 0px;"
                                                 data-bind="
                                                     select2Query: {
@@ -383,7 +387,7 @@
                                         <span data-bind="text: $data.resourceName"></span>
                                         <span data-bind="text: $root.translations.relationshipToResource"></span>
                                     </div>
-    
+
                                     <div class="row" style="padding: 0px 12px; margin-bottom: 10px;">
                                         <!-- rr name -->
                                         <span class="col-xs-12" style="text-align: left;"
@@ -392,7 +396,7 @@
 
                                         <!-- Property -->
                                         <span class="col-xs-12">
-                                            <select 
+                                            <select
                                                 style="width:100%; display:inline-block; margin: 3px 0px;"
                                                 data-bind="
                                                     select2Query: {
@@ -429,6 +433,7 @@
     <!-- /ko -->
     <!-- /ko -->
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -67,7 +67,7 @@
                         entities_greek: false
                     },
                     valueUpdate: 'afterkeydown',
-                    attr: {disabled: disabled}
+                    attr: {disabled: disable}
                 "></textarea>
         </div>
     </div>

--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -94,6 +94,7 @@
         attr: {disabled: disabled}
     "
 ></textarea>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block report %}

--- a/arches/app/templates/views/components/widgets/select.htm
+++ b/arches/app/templates/views/components/widgets/select.htm
@@ -64,4 +64,5 @@
         </div>
     </div>
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/select.htm
+++ b/arches/app/templates/views/components/widgets/select.htm
@@ -14,7 +14,7 @@
                 data-bind="select2Query: {
                     select2Config: {
                         clickBubble: true,
-                        disabled: disabled,
+                        disabled: disable,
                         data: options,
                         value: value,
                         multiple: multiple,

--- a/arches/app/templates/views/components/widgets/switch.htm
+++ b/arches/app/templates/views/components/widgets/switch.htm
@@ -7,7 +7,7 @@
           onEnterkeyClick, onSpaceClick, click: setvalue, attr: {'aria-checked': getariavalue(), 'aria-label': label() + ', ' + localizedSubtitle()}" tabindex="0" role="checkbox"
     ><small></small></span>
             <div style="display:flex; flex-direction:row;">
-            <div class="arches-toggle-sm" data-bind="text:label, css: {'disabled': disabled}"></div>
+            <div class="arches-toggle-sm" data-bind="text:label, css: {'disabled': disable}"></div>
                 <div style="margin-top: -17px;">
                 <!-- ko if: node -->
                 <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>

--- a/arches/app/templates/views/components/widgets/switch.htm
+++ b/arches/app/templates/views/components/widgets/switch.htm
@@ -3,7 +3,7 @@
 
 {% block form %}
 <div class="toggle-container" data-bind="let: {uid: Math.random().toString()}, class: nodeCssClasses">
-    <span class="switch switch-small switch-widget" data-bind="css: {'on': getvalue() === true, 'null': getvalue() === null, 'disabled': disabled },
+    <span class="switch switch-small switch-widget" data-bind="css: {'on': getvalue() === true, 'null': getvalue() === null, 'disabled': disable },
           onEnterkeyClick, onSpaceClick, click: setvalue, attr: {'aria-checked': getariavalue(), 'aria-label': label() + ', ' + localizedSubtitle()}" tabindex="0" role="checkbox"
     ><small></small></span>
             <div style="display:flex; flex-direction:row;">

--- a/arches/app/templates/views/components/widgets/switch.htm
+++ b/arches/app/templates/views/components/widgets/switch.htm
@@ -38,4 +38,5 @@
             </div>
     <span class="arches-toggle-subtitle" data-bind="text: localizedSubtitle, attr: {id: uid}"></span>
 </div>
+{{ block.super }}
 {% endblock config_form %}

--- a/arches/app/templates/views/components/widgets/text.htm
+++ b/arches/app/templates/views/components/widgets/text.htm
@@ -169,24 +169,7 @@
     </div>
     </div>
 </div>
-<div class="node-config-item">
-    <div class="control-label">
-        <span class="widget-input-label" data-bind="text: $root.translations.disabled"></span>
-    </div>
-    <div class="pad-no">
-        <div
-            data-bind="
-                component: {
-                    name: 'views/components/simple-switch',
-                    params: {
-                        value: uneditable,
-                        config:{label: $root.translations.disableEditing, subtitle: $root.translations.preventUsersFromEditingValue}
-                    }
-                }
-            "
-        ></div>
-    </div>
-</div>
+{{ block.super }}
 {% endblock config_form %}
 
 <!-- ko if: !configForm  && state === 'display_value' -->

--- a/arches/app/templates/views/components/widgets/urldatatype.htm
+++ b/arches/app/templates/views/components/widgets/urldatatype.htm
@@ -13,7 +13,7 @@
             </label>
         </div>
         <div class="col-xs-12">
-            <input type="string" data-bind="textInput: url_label, attr: {placeholder: url_label_placeholder}" class="form-control input-lg widget-input" style="margin-bottom: 5px">
+            <input type="string" data-bind="disable: disabled, textInput: url_label, attr: {placeholder: url_label_placeholder}" class="form-control input-lg widget-input" style="margin-bottom: 5px">
         </div>
         <div class="control-label">
             <label class="control-label widget-input-label" for="">
@@ -21,7 +21,7 @@
             </label>
         </div>
         <div class="col-xs-12">
-            <input type="string" data-bind="textInput: url, attr: {placeholder: url_placeholder}" class="form-control
+            <input type="string" data-bind="disable: disabled, textInput: url, attr: {placeholder: url_placeholder}" class="form-control
             input-lg widget-input" style="margin-bottom: 5px">
         </div>
         <div class="col-xs-12">
@@ -37,7 +37,6 @@
     </div>
 </div>
 {% endblock form %}
-
 
 {% block config_form %}
 <div class="control-label">
@@ -61,8 +60,8 @@
     <input type="" id="" class="form-control input-md widget-input"
     data-bind="textInput: link_color">
 </div>
+{{ block.super }}
 {% endblock config_form %}
-
 
 {% block report %}
 <dt data-bind="text: label, class: nodeCssClasses"></dt>

--- a/arches/app/templates/views/components/widgets/urldatatype.htm
+++ b/arches/app/templates/views/components/widgets/urldatatype.htm
@@ -13,7 +13,7 @@
             </label>
         </div>
         <div class="col-xs-12">
-            <input type="string" data-bind="disable: disabled, textInput: url_label, attr: {placeholder: url_label_placeholder}" class="form-control input-lg widget-input" style="margin-bottom: 5px">
+            <input type="string" data-bind="disable: disable, textInput: url_label, attr: {placeholder: url_label_placeholder}" class="form-control input-lg widget-input" style="margin-bottom: 5px">
         </div>
         <div class="control-label">
             <label class="control-label widget-input-label" for="">
@@ -21,7 +21,7 @@
             </label>
         </div>
         <div class="col-xs-12">
-            <input type="string" data-bind="disable: disabled, textInput: url, attr: {placeholder: url_placeholder}" class="form-control
+            <input type="string" data-bind="disable: disable, textInput: url, attr: {placeholder: url_placeholder}" class="form-control
             input-lg widget-input" style="margin-bottom: 5px">
         </div>
         <div class="col-xs-12">


### PR DESCRIPTION
- This PR adds a toggle to each datatype/widget's card to "Disable Editing" by updating each widget's `defaultconfig`, adding the HTML for the toggle to the widget's `base.htm` and calling `{{ block.super }}` on child widget's that extend `base.htm`.
- The two datatypes/widgets that are more complex and slightly differ from the rest are `map-widget-editor.htm` and `iiif-widget-annotation.htm`.
- I chose an arbitrary issue number for the migration file. I am happy to change it if/when we create an issue for this in Arches.
- We will need to merge: https://github.com/bcgov/nr-bcap/pull/1201 to see these changes reflected in BCAP.