### PR TITLE
Fix CKEditor Timing Issue

### DIFF
--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -123,6 +123,9 @@ ko.bindingHandlers.ckeditor = {
     init: (element, valueAccessor, allBindings) => {
         window.jQuery = $;
         require(['ckeditor4', 'ckeditor-jquery'], () => {
+            if (!document.body.contains(element)) {
+                return;
+            }
             initialize(element, valueAccessor, allBindings);
         });
     }


### PR DESCRIPTION
There appears to be a timing issue due to CKEditor loading asynchronously. The CKEditor was failing on a stale element and that failure was blocking all future attempts, so it ended up in a broken state.

A fix is adding a check to ensure the element is still in the DOM.

This would fix: https://github.com/bcgov/nr-bcap/issues/1274