### PR TITLE
Fix CKEditor Timing Issue

### DIFF
--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -14,6 +14,10 @@ import arches from 'arches';
 */
 
 const initialize = function (element, valueAccessor, allBindings) {
+    if (!element.isConnected) {
+        return;
+    }
+
     var modelValue = valueAccessor();
     var value = ko.utils.unwrapObservable(valueAccessor());
     const language = allBindings.get('language') || ko.observable(arches.activeLanguage);


### PR DESCRIPTION
There appears to be a timing issue due to CKEditor loading asynchronously. The CKEditor was failing on a stale element and that failure was blocking all future attempts, so it ended up in a broken state.

A fix is adding a check to ensure the element is still in the DOM.

This would fix: [bcgov/nr-bcap#1274](https://github.com/bcgov/nr-bcap/issues/1274)

Supercedes: [bcgov/arches#7](https://github.com/bcgov/arches/pull/7)